### PR TITLE
added missing dependency to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,10 @@ com.thattonybo.scribble
 ```
 
 ## Flatpak
-Ensure the SDK is installed:
+Ensure the SDK and Platform are installed:
 ```shell
 flatpak install --user io.elementary.Sdk//7.2
+flatpak install --user io.elementary.Platform//7.2
 ```
 Build with flatpak-builder:
 ```shell


### PR DESCRIPTION
added missing dependency to instructions for building the flatpak version in README.md. This allowed me to install `scribble` on 8.0.